### PR TITLE
Only encode as HTML for browser clients

### DIFF
--- a/src/gorilla_repl/render_values_mw.clj
+++ b/src/gorilla_repl/render_values_mw.clj
@@ -23,7 +23,7 @@
                                      (recv [this timeout] (.recv transport timeout))
                                      (send [this resp]
                                        (.send transport
-                                              (if-let [[_ v] (find resp :value)]
+                                              (if-let [[_ v] (and (:as-html msg) (find resp :value))]
                                                 ;; we have to transform the rendered value to JSON here, as otherwise
                                                 ;; it will be pr'ed by the pr-values middleware (which comes with the
                                                 ;; eval middleware), meaning that it won't be mapped to JSON when the

--- a/src/gorilla_repl/websocket_relay.clj
+++ b/src/gorilla_repl/websocket_relay.clj
@@ -28,7 +28,7 @@
 
 (defn- process-message
   [channel data]
-  (let [parsed-message (json/parse-string data true)
+  (let [parsed-message (assoc (json/parse-string data true) :as-html 1)
         client (nrepl/client @conn Long/MAX_VALUE)
         replies (nrepl/message client parsed-message)]
     ;; send the messages out over the WS connection one-by-one.


### PR DESCRIPTION
This changes the middleware HTML renderer so that it only
lights up when the `:as-html` marker is present in the nREPL
request.

Use case: textual nREPL clients like vim-fireplace or lein repl
(when using the :connect option) shouldn't see HTML.
