### PR TITLE
Adds image-view to render BufferedImages.

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -14,7 +14,8 @@
                  [org.slf4j/slf4j-api "1.7.5"]
                  [ch.qos.logback/logback-classic "1.0.13"]
                  [clojure-complete "0.2.3"]
-                 [gorilla-renderable "1.0.0"]]
+                 [gorilla-renderable "1.0.0"]
+                 [org.clojure/data.codec "0.1.0"]]
   :main ^:skip-aot gorilla-repl.core
   :target-path "target/%s"
   :plugins [[lein-ring "0.8.7"]]

--- a/src/gorilla_repl/image.clj
+++ b/src/gorilla_repl/image.clj
@@ -1,0 +1,41 @@
+;;;; This file is part of gorilla-repl. Copyright (C) 2014-, Jony Hudson
+;;;;
+;;;; gorilla-repl is licenced to you under the MIT licence. See the file LICENCE.txt for full details.
+
+(ns gorilla-repl.image
+  (:import [java.awt Image]
+           [java.awt.image BufferedImage]
+           [java.io ByteArrayOutputStream]
+           [javax.imageio ImageIO])
+  (:require [clojure.data.codec.base64 :as b64]
+            [clojure.string :as string]
+            [gorilla-renderable.core :as render]))
+
+(defn image-to-bytes [^Image image ^String type width height]
+  (let [bi (BufferedImage. width height (if (#{"png" "gif"} type)
+                                          BufferedImage/TYPE_INT_ARGB
+                                          BufferedImage/TYPE_INT_RGB))
+        baos (ByteArrayOutputStream.)]
+    (doto (.getGraphics bi) (.drawImage image 0 0 width height nil))
+    (ImageIO/write bi type baos)
+    (.toByteArray baos)))
+
+(defrecord ImageView [image alt type width height]
+  render/Renderable
+  (render [{:keys [image alt type width height]}]
+      {:type :html
+       :content (format "<img src=\"data:image/%1$s;base64,%2$s\" width=\"%3$s\" height=\"%4$s\" alt=\"%5$s\" />"
+                        type (String. (b64/encode (image-to-bytes image type width height))) width height alt)
+       :value (pr-str image)}))
+
+(defn image-view [^BufferedImage image & {:keys [alt type width height]}]
+  (let [alt (or alt "")
+        type (string/lower-case (or type "png"))
+        iw (.getWidth image)
+        ih (.getHeight image)
+        [w h] (cond
+               (and width height) [(int width) (int height)]
+               width [(int width) (int (* (/ width iw) ih))]
+               height [(int (* (/ height ih) iw)) (int height)]
+               :else [iw ih])]
+    (ImageView. image alt type w h)))


### PR DESCRIPTION
Straw man implementation of image-view. To test:

``` clojure
(import javax.imageio.ImageIO)
(require '[clojure.java.io :as io])
(def i (ImageIO/read (io/file "screenshot.png")))
(use 'gorilla-repl.image)
(image-view i)
```

Options supported by `image-view` are:

`:alt` : alt text for the image tag. Default "".
`:type` : output format of the image ("bmp", "gif", "png", "jpg"). Default "png".
`:width` : width of the output image. Default input image width.
`:height` : height of the output image. Default input image height.

Aspect ratio is preserved if only one of the size options is specified.
