### PR TITLE
Listen by default only on localhost

### DIFF
--- a/src/gorilla_repl/core.clj
+++ b/src/gorilla_repl/core.clj
@@ -111,7 +111,7 @@
     ;; first startup nREPL
     (nrepl/start-and-connect nrepl-requested-port)
     ;; and then the webserver
-    (server/run-server app-routes {:port webapp-port :join? false})
+    (server/run-server app-routes {:port webapp-port :join? false :ip "127.0.0.1"})
     (println (str "Running at http://localhost:" webapp-port "/worksheet.html ."))
     (println "Ctrl+C to exit.")))
 


### PR DESCRIPTION
- Gorilla-REPL provides a non-sandboxed, un-authenticated REPL to everyone
  who can connect to a machine listening on 8990 on any of its active
  network interfaces

> grep gorilla project.clj
> (defproject gorilla-transit "0.1.0-SNAPSHOT"
>   :main ^:skip-aot gorilla-transit.core
>   :plugins [[lein-gorilla "0.3.1" ]]
> 
> netstat -na | grep 8990
> tcp46      0      0  _.8990                 *._                    LISTEN
- One major issue is providing read access to SSH private keys:
  (slurp "/Users/$USER/.ssh/id_rsa")
  "-----BEGIN RSA PRIVATE KEY-----\nM
