### PR TITLE
Fix for lein gorilla not working on some setups

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -8,14 +8,15 @@
   :license {:name "MIT"}
   :dependencies [[org.clojure/clojure "1.6.0"]
                  [http-kit "2.1.16"]
-                 [ring/ring-json "0.2.0"]
+                 [ring/ring-json "0.3.1"]
                  [cheshire "5.0.2"]
-                 [compojure "1.1.6"]
+                 [compojure "1.1.8"]
                  [org.slf4j/slf4j-api "1.7.5"]
                  [ch.qos.logback/logback-classic "1.0.13"]
                  [clojure-complete "0.2.3"]
                  [gorilla-renderable "1.0.0"]
                  [org.clojure/data.codec "0.1.0"]
+                 [javax.servlet/servlet-api "2.5"]
                  [grimradical/clj-semver "0.2.0" :exclusions [org.clojure/clojure]]]
   :main ^:skip-aot gorilla-repl.core
   :target-path "target/%s"


### PR DESCRIPTION
I initially was getting `java.io.FileNotFoundException: Could not locate ring/middleware/head__init.class or ring/middleware/head.clj on classpath`

After googling a bit around toying around with **project.clj** settings I found using later versions of **ring-json** and **compojure** got me to a newer exception which is referenced in the issue here https://github.com/ring-clojure/ring/issues/100 

after adding the dependency on `javax.servlet/servlet-api` I can now run `lein gorilla` with this update. 
