### PR TITLE
override lein magic & generate deps that work in the Java ecosystem

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -6,18 +6,20 @@
   :description "A rich REPL for Clojure in the notebook style."
   :url "https://github.com/JonyEpsilon/gorilla-repl"
   :license {:name "MIT"}
-  :dependencies [[org.clojure/clojure "1.6.0"]
-                 [http-kit "2.1.18"]
-                 [ring/ring-json "0.3.1"]
-                 [cheshire "5.3.1"]
-                 [compojure "1.1.8"]
-                 [org.slf4j/slf4j-api "1.7.7"]
-                 [ch.qos.logback/logback-classic "1.1.2"]
-                 [gorilla-renderable "1.0.0"]
-                 [org.clojure/data.codec "0.1.0"]
-                 [javax.servlet/servlet-api "2.5"]
-                 [grimradical/clj-semver "0.2.0" :exclusions [org.clojure/clojure]]
-                 [cider/cider-nrepl "0.7.0"]]
+  :dependencies ^:replace [[org.clojure/clojure "1.6.0"]
+                           [http-kit "2.1.18"]
+                           [ring/ring-json "0.3.1"]
+                           [cheshire "5.3.1"]
+                           [compojure "1.1.8"]
+                           [org.slf4j/slf4j-api "1.7.7"]
+                           [ch.qos.logback/logback-classic "1.1.2"]
+                           [gorilla-renderable "1.0.0"]
+                           [org.clojure/data.codec "0.1.0"]
+                           [javax.servlet/servlet-api "2.5"]
+                           [grimradical/clj-semver "0.2.0" :exclusions [org.clojure/clojure]]
+                           [cider/cider-nrepl "0.7.0"]
+                           [org.clojure/tools.nrepl "0.2.3"]
+                           [clojure-complete "0.2.3"]]
   :main ^:skip-aot gorilla-repl.core
   :target-path "target/%s"
   :profiles {:uberjar {:aot :all}})


### PR DESCRIPTION
The ^:replace may not be lein-idiomatic, I added it based on discussion at https://github.com/technomancy/leiningen/issues/1569
