### PR TITLE
Add commands for clearing output of code segments.

### DIFF
--- a/resources/public/js/commandProcessor.js
+++ b/resources/public/js/commandProcessor.js
@@ -212,5 +212,23 @@ commandList = [
         action: function () {
             eventBus.trigger("worksheet:completions");
         }
+    },
+    {
+        name: "command:worksheet:clear-output",
+        desc: "Clear the output of the highlighted segment.",
+        showInMenu: true,
+        kb: combo('g', 'o'),
+        action: function () {
+            eventBus.trigger("worksheet:clear-output");
+        }
+    },
+    {
+        name: "command:worksheet:clear-all",
+        desc: "Clear the output of all code segments.",
+        showInMenu: true,
+        kb: combo('g', 'z'),
+        action: function () {
+            eventBus.trigger("worksheet:clear-all-output");
+        }
     }
 ];

--- a/resources/public/js/worksheet.js
+++ b/resources/public/js/worksheet.js
@@ -304,6 +304,26 @@ var worksheet = function () {
                 }
             }
         });
+
+        // * Clearing output *
+
+        var clearSegment = function(seg) {
+            if (seg == null) return;
+            if (seg.type == "code") {
+                seg.clearOutput();
+                seg.clearErrorAndConsole();
+                seg.runningIndicator(false);
+            }
+        };
+
+        addEventHandler("worksheet:clear-output", function() {
+            var seg = self.getActiveSegment();
+            clearSegment(seg);
+        });
+
+        addEventHandler("worksheet:clear-all-output", function() {
+            self.segments().forEach(clearSegment);
+        });
     };
 
     return self;


### PR DESCRIPTION
When using Gorilla for demos or tutorials, I generally want to start the presentation with a a worksheet that has code segments but no output.  This pull request adds two commands for clearing the output of either the current segment or all code segments in the worksheet, making it easy to clean up a tutorial worksheet for publication of presentation.
