### PR TITLE
Added viewer implementation for Bitbucket repositories (issue #197)

### DIFF
--- a/resources/public/js-viewer/bitbucket.js
+++ b/resources/public/js-viewer/bitbucket.js
@@ -1,0 +1,9 @@
+/*
+ * This file is part of gorilla-repl. Copyright (C) 2014-, Jony Hudson.
+ *
+ * gorilla-repl is licenced to you under the MIT licence. See the file LICENCE.txt for full details.
+ */
+
+var getFromBitbucket = function (user, repo, path, revision, callback) {
+    $.get("https://bitbucket.org/api/1.0/repositories/" + user + "/" + repo + "/raw/" + revision + "/" + path, callback);
+};

--- a/resources/public/js-viewer/main-viewer.js
+++ b/resources/public/js-viewer/main-viewer.js
@@ -16,6 +16,7 @@ var app = function () {
     });
     self.sourceURL = ko.observable("");
     self.source = ko.observable("");
+    self.host = ko.observable("");
 
     // The copyBox is a UI element that gives links to the source of the worksheet, and how to copy/edit it.
     self.copyBoxVisible = ko.observable(false);
@@ -34,6 +35,7 @@ var app = function () {
         self.sourceURL(sourceURL);
         self.filename(worksheetName);
         self.source(source);
+        self.host((source.toLowerCase() === "bitbucket") ? "Bitbucket" : "GitHub");
 
         // wire up the UI
         ko.applyBindings(self, document.getElementById("document"));
@@ -70,6 +72,15 @@ $(function () {
             var filename = getParameterByName("filename");
             getFromGist(id, filename, function (data) {
                 viewer.start(data,  "https://gist.github.com/" + id, filename, source);
+            });
+            return;
+        case "bitbucket":
+            var user = getParameterByName("user");
+            var repo = getParameterByName("repo");
+            var path = getParameterByName("path");
+            var revision = getParameterByName("revision") || "HEAD";
+            getFromBitbucket(user, repo, path, revision, function (data) {
+                viewer.start(data, "https://bitbucket.org/" + user + "/" + repo, path, source);
             });
             return;
         case "test":

--- a/resources/public/view.html
+++ b/resources/public/view.html
@@ -39,6 +39,7 @@
     <script type="text/javascript" src="js-viewer/segment-viewer.js"></script>
     <script type="text/javascript" src="js-viewer/worksheet-viewer.js"></script>
     <script type="text/javascript" src="js-viewer/github.js"></script>
+    <script type="text/javascript" src="js-viewer/bitbucket.js"></script>
     <script type="text/javascript" src="js-viewer/main-viewer.js"></script>
 
     <title data-bind="text: title">Gorilla REPL viewer</title>
@@ -50,7 +51,7 @@
     <div class="header-left">Made with <a href="http://clojure.org" target="_blank">Clojure</a> and
         <a href="http://gorilla-repl.org" target="_blank">Gorilla REPL</a></div>
     <div class="header-right">
-        <a href="#" data-bind="click: showCopyBox">View this worksheet on GitHub</a>
+        <a href="#" data-bind="click: showCopyBox">View this worksheet on <span data-bind="text: host"></span></a>
     </div>
 </div>
 
@@ -99,7 +100,7 @@
 
 <!-- Copying instructions -->
 <div class="copyBox" style="display: none" data-bind="visible: copyBoxVisible">
-    <p>This code can be found on GitHub here:</p>
+    <p>This code can be found on <span data-bind="text: host"></span> here:</p>
     <div data-bind="visible: (!(source().toLowerCase() === 'gist'))">
         <a data-bind="attr: {href: sourceURL}, text: sourceURL" target="_blank"></a>
         </div>
@@ -113,7 +114,7 @@
     <ul>
         <li>If you don't yet have Leiningen installed, then follow the instructions
             <a href="http://leiningen.org/#install" target="_blank">here</a>. It only takes a couple of minutes.</li>
-        <li>Clone the GitHub project that contains this worksheet:
+        <li>Clone the <span data-bind="text: host"></span>  project that contains this worksheet:
             <a data-bind="attr: {href: sourceURL}, text: sourceURL" target="_blank"></a>.</li>
         <li>Open a terminal in the project directory and run "lein gorilla".</li>
         <li>Open the load dialog by pressing "alt+g alt+l" ("ctrl+g ctrl+l" on Mac).</li>


### PR DESCRIPTION
Hi, I also wanted to use the viewer for workbooks hosted in Bitbucket repos, and put together a small implementation.

The keys used in the `view.html` querystring are identical to those used for GitHub repositories, with one additional key `revision`, which defaults to "HEAD" (it is possible via the Bitbucket API to request a particular revision). Bitbucket repositories are served when `source=bitbucket`.

The main notable change is to add a new KO data-bind variable, `host`, reflecting where the workbook is hosted; this then is used instead of the hard-coded "GitHub" text in `view.html`. This value defaults to "GitHub" for the currently-supported GitHub repositories and gists, unless the `source` is set to `bitbucket`, in which case it is changed to "Bitbucket".

Thanks!