### PR TITLE
automatically open the worksheet URL in the browser

### DIFF
--- a/src/gorilla_repl/core.clj
+++ b/src/gorilla_repl/core.clj
@@ -99,9 +99,11 @@
     (nrepl/start-and-connect nrepl-requested-port)
     ;; and then the webserver
     (let [s (server/run-server #'app-routes {:port webapp-requested-port :join? false :ip ip})
-          webapp-port (:local-port (meta s))]
+          webapp-port (:local-port (meta s))
+          url (str "http://" ip ":" webapp-port "/worksheet.html")]
       (spit (doto (io/file ".gorilla-port") .deleteOnExit) webapp-port)
-      (println (str "Running at http://" ip ":" webapp-port "/worksheet.html ."))
+      (.. java.awt.Desktop getDesktop (browse (java.net.URI. url))) 
+      (println (str "Running at " url "."))
       (println "Ctrl+C to exit."))))
 
 (defn -main

--- a/src/gorilla_repl/core.clj
+++ b/src/gorilla_repl/core.clj
@@ -102,9 +102,13 @@
           webapp-port (:local-port (meta s))
           url (str "http://" ip ":" webapp-port "/worksheet.html")]
       (spit (doto (io/file ".gorilla-port") .deleteOnExit) webapp-port)
-      (.. java.awt.Desktop getDesktop (browse (java.net.URI. url))) 
-      (println (str "Running at " url "."))
-      (println "Ctrl+C to exit."))))
+      (println "Running at" url)
+      (println "Ctrl+C to exit")
+      (try
+        (.. java.awt.Desktop getDesktop (browse (java.net.URI. url))) 
+        (catch java.awt.HeadlessException e 
+          ;; running headless
+          nil)))))
 
 (defn -main
   [& args]


### PR DESCRIPTION
Many notebooks automatically open the notebook URL in the browser upon launch. This functionality is easy to implement in Java. If desired, it can be made optional, with either default, but I thought that the fewer options the better.
