### PR TITLE
Separated nrepl code, added CLI options, added failover

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,4 @@ pom.xml.asc
 *.iml
 .DS_Store
 ws/
+Procfile

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## Version 0.4.0
+- Can start GorillaREPL without starting nrepl
+
+
 ## Version 0.3.5
 
 - Can view worksheets hosted on BitBucket (thanks for @tbrx).

--- a/Procfile
+++ b/Procfile
@@ -1,0 +1,1 @@
+service: java  -Xmx4g -jar gorillarepl.jar -p7888 -P9000

--- a/README.md
+++ b/README.md
@@ -3,6 +3,9 @@
 Gorilla is a rich REPL for Clojure in the notebook style. If you're interested you should take a look at its
 [website](http://gorilla-repl.org).
 
+This fork separates the nrepl related stuff you need to include in your project from the actual GoriallaREPL app code
+which relies on a nrepl being present.
+
 ## Contributing
 
 Contributions, in the form of comments, criticism, bug reports, or code are all very welcome :-) If you've got an idea

--- a/project.clj
+++ b/project.clj
@@ -14,6 +14,7 @@
                            [compojure "1.1.8"]
                            [org.slf4j/slf4j-api "1.7.7"]
                            [ch.qos.logback/logback-classic "1.1.2"]
+                           [org.clojure/tools.logging "0.3.1"]
                            [gorilla-renderable "2.0.0"]
                            [gorilla-plot "0.1.3"]
                            [javax.servlet/servlet-api "2.5"]

--- a/project.clj
+++ b/project.clj
@@ -2,11 +2,12 @@
 ;;;;
 ;;;; gorilla-repl is licenced to you under the MIT licence. See the file LICENCE.txt for full details.
 
-(defproject gorilla-repl "0.3.5-SNAPSHOT"
+(defproject gorilla-repl "0.4.0-SNAPSHOT"
   :description "A rich REPL for Clojure in the notebook style."
   :url "https://github.com/JonyEpsilon/gorilla-repl"
   :license {:name "MIT"}
   :dependencies ^:replace [[org.clojure/clojure "1.6.0"]
+                           [org.clojure/tools.cli "0.3.1"]
                            [http-kit "2.1.18"]
                            [ring/ring-json "0.3.1"]
                            [cheshire "5.3.1"]
@@ -22,3 +23,10 @@
   :main ^:skip-aot gorilla-repl.core
   :target-path "target/%s"
   :profiles {:uberjar {:aot :all}})
+
+
+;; Run using
+
+;;   lein run -p 7999
+
+;; to connect to an existing nrepl server.

--- a/resources/logback.xml
+++ b/resources/logback.xml
@@ -6,7 +6,7 @@
         </encoder>
     </appender>
 
-    <root level="ERROR">
+    <root level="INFO">
         <appender-ref ref="stdout" />
     </root>
 

--- a/src/gorilla_repl/cli.clj
+++ b/src/gorilla_repl/cli.clj
@@ -1,0 +1,67 @@
+(ns gorilla-repl.cli
+  (:require [clojure.tools.cli :as cli]
+            [clojure.string :as string]))
+
+(def cli-options                                            ;; see https://github.com/clojure/tools.cli#example-usage
+  ;; An option with a required argument
+  (let [glob-expression #"[0-9\?\*\[\]\-\^\{\}\\\,]*"
+        env-expression #"[0-9a-zA-Z\-\.]*"
+        ]
+    [["-s" "--standalone" "Start nrepl server inside GorillaREPL process."
+      :id :standalone
+      ]
+
+     ["-p" "--nrepl-port PORT" "Port number of the nrepl server."
+      :default 9001
+      :parse-fn #(Integer/parseInt %)
+      :validate [#(< 0 % 0x10000) "Must be a number between 0 and 65536"]]
+     ["-h" "--nrepl-host HOST" "host of the nrepl server."
+      :default "localhost"
+      ;; Specify a string to output in the default column in the options summary
+      ;; if the default value's string representation is very ugly
+      :default-desc "localhost"]
+
+
+     ["-P" "--port PORT" "Port number of the GorillaREPL server."
+      :default 9000
+      :parse-fn #(Integer/parseInt %)
+      :validate [#(< 0 % 0x10000) "Must be a number between 0 and 65536"]]
+     ["-H" "--host HOST" "host of the GorillaREPL server."
+      :default "localhost"
+      ;; Specify a string to output in the default column in the options summary
+      ;; if the default value's string representation is very ugly
+      :default-desc "localhost"]
+
+     [nil "--project PROJECT" "name of the project."]
+
+     [nil "--help"]]))
+
+(defn usage [options-summary]
+  (->> ["GorillaREPL, can use an embedded nrepl-sever (standalone) or connect to an existing one."
+        ""
+        ""
+        "Options:"
+        options-summary
+        ""
+        ""
+        ]
+       (string/join \newline)))
+
+(defn error-msg [errors]
+  (str "The following errors occurred while parsing your command:\n\n"
+       (string/join \newline errors)))
+
+(defn exit [status msg]
+  (println msg)
+  (System/exit status))
+
+
+(defn parse-opts [args]
+  (let [{:keys [options arguments errors summary] :as parsed} (cli/parse-opts args cli-options)]
+
+    (cond
+      (:help options) (exit 0 (usage summary))
+      ;(not= (count arguments) 1) (exit 1 (usage summary))
+      (not-empty errors) (exit 1 (error-msg errors)))
+    parsed
+    ))

--- a/src/gorilla_repl/core.clj
+++ b/src/gorilla_repl/core.clj
@@ -13,11 +13,12 @@
             [ring.util.response :as res]
             [gorilla-repl.nrepl :as nrepl]
             [gorilla-repl.websocket-relay :as ws-relay]
-            [gorilla-repl.renderer :as renderer] ;; this is needed to bring the render implementations into scope
+            [gorilla-repl.renderer :as renderer]            ;; this is needed to bring the render implementations into scope
             [gorilla-repl.files :as files]
             [gorilla-repl.version :as version]
             [clojure.set :as set]
-            [clojure.java.io :as io])
+            [clojure.java.io :as io]
+            [gorilla-repl.cli :as cli])
   (:gen-class))
 
 
@@ -57,7 +58,7 @@
 ;; API endpoint for getting the list of worksheets in the project
 (defn gorilla-files [req]
   (let [excludes @excludes]
-  (res/response {:files (files/gorilla-filepaths-in-current-directory excludes)})))
+    (res/response {:files (files/gorilla-filepaths-in-current-directory excludes)})))
 
 ;; configuration information that will be made available to the webapp
 (def conf (atom {}))
@@ -84,7 +85,6 @@
   (let [version (or (:version conf) "develop")
         webapp-requested-port (or (:port conf) 0)
         ip (or (:ip conf) "127.0.0.1")
-        nrepl-requested-port (or (:nrepl-port conf) 0)  ;; auto-select port if none requested
         project (or (:project conf) "no project")
         keymap (or (:keymap (:gorilla-options conf)) {})
         _ (swap! excludes (fn [x] (set/union x (:load-scan-exclude (:gorilla-options conf)))))]
@@ -94,9 +94,7 @@
     (set-config :project project)
     (set-config :keymap keymap)
     ;; check for updates
-    (version/check-for-update version)  ;; runs asynchronously
-    ;; first startup nREPL
-    (nrepl/start-and-connect nrepl-requested-port)
+    (version/check-for-update version)                      ;; runs asynchronously
     ;; and then the webserver
     (let [s (server/run-server #'app-routes {:port webapp-requested-port :join? false :ip ip})
           webapp-port (:local-port (meta s))]
@@ -106,4 +104,23 @@
 
 (defn -main
   [& args]
-  (run-gorilla-server {:port 8990}))
+
+  (let [{:keys [options arguments errors summary]} (cli/parse-opts args)]
+
+    (println options)
+
+    ;; first startup nREPL
+
+    (if (:standalone options)
+      (let [port (nrepl/start (or (:nrepl-port options) 0))]   ;; auto-select port if none requested
+        (nrepl/connect (or (:nrepl-host options) "127.0.0.1") port))
+
+      (nrepl/connect (:nrepl-host options) (:nrepl-port options)))
+
+
+    ;; then start the actual GorillaREPL server
+    (run-gorilla-server {:port (:port options)
+                         :ip (:host options)
+                         :project (:project options)
+                         })))
+

--- a/src/gorilla_repl/nrepl.clj
+++ b/src/gorilla_repl/nrepl.clj
@@ -9,7 +9,8 @@
 
 (def nrepl (atom nil))
 
-(defn start-and-connect
+(defn start
+  "Starts a new nrepl server and return the port it binds to."
   [nrepl-requested-port]
   (let [cider-mw (map resolve cider/cider-middleware)
         middleware (conj cider-mw #'render-mw/render-values)
@@ -19,5 +20,13 @@
         repl-port-file (io/file ".nrepl-port")]
     (println "Started nREPL server on port" nrepl-port)
     (swap! nrepl (fn [x] nr))
-    (ws-relay/connect-to-nrepl nrepl-port)
-    (spit (doto repl-port-file .deleteOnExit) nrepl-port)))
+    (spit (doto repl-port-file .deleteOnExit) nrepl-port)
+    nrepl-port
+    ))
+
+
+
+(defn connect
+  "Connects to an existing nrepl server using the host/port specified"
+  [host port]
+  (ws-relay/connect-to-nrepl host port))

--- a/src/gorilla_repl/websocket_relay.clj
+++ b/src/gorilla_repl/websocket_relay.clj
@@ -16,8 +16,8 @@
 ;; routing macro, so I can't pass the connection around, to give a more functional API.
 (defn connect-to-nrepl
   "Connect to the nREPL server and store the connection."
-  [port]
-  (let [new-conn (nrepl/connect :port port)]
+  [host port]
+  (let [new-conn (nrepl/connect :host host :port port)]
     (swap! conn (fn [x] new-conn))))
 
 (defn- send-json-over-ws

--- a/src/gorilla_repl/websocket_relay.clj
+++ b/src/gorilla_repl/websocket_relay.clj
@@ -7,18 +7,26 @@
 (ns gorilla-repl.websocket-relay
   (:require [org.httpkit.server :as server]
             [clojure.tools.nrepl :as nrepl]
-            [cheshire.core :as json]))
+            [cheshire.core :as json]
+            [clojure.tools.logging :as log])
+  (:import (java.net SocketException)))
 
 ;; We will open a single connection to the nREPL server for the life of the application. It will be stored here.
-(def conn (atom nil))
+(defonce conn (atom {}))
 
 ;; Doing it this way with an atom feels wrong, but I can't figure out how to thread an argument into Compojure's
 ;; routing macro, so I can't pass the connection around, to give a more functional API.
 (defn connect-to-nrepl
   "Connect to the nREPL server and store the connection."
   [host port]
-  (let [new-conn (nrepl/connect :host host :port port)]
-    (swap! conn (fn [x] new-conn))))
+  (swap! conn assoc :host host :port port)
+  (try
+    (let [new-conn (nrepl/connect :host host :port port)]
+      (swap! conn assoc :connection new-conn))
+    (catch Exception e
+      (log/warn "Error connecting to nrepl server. Maybe the nrepl server has problems or there are problems connecting.
+      GorillaREPL will be up and running, trying to reconnect if necessary."))))
+
 
 (defn- send-json-over-ws
   [channel data]
@@ -26,13 +34,24 @@
     #_(println json-data)
     (server/send! channel json-data)))
 
-(defn- process-message
-  [channel data]
+(defn- process-message* [channel data]
   (let [parsed-message (assoc (json/parse-string data true) :as-html 1)
-        client (nrepl/client @conn Long/MAX_VALUE)
+        client (nrepl/client (:connection @conn) Long/MAX_VALUE)
         replies (nrepl/message client parsed-message)]
     ;; send the messages out over the WS connection one-by-one.
     (doall (map (partial send-json-over-ws channel) replies))))
+
+(defn- process-message
+  [channel data]
+  (when-not (:connection @conn)
+    (log/warn "No connection to nrepl, trying to re-establish (1)!")
+    (connect-to-nrepl (:host @conn) (:port @conn)))
+  (try
+    (process-message* channel data)
+    (catch SocketException e
+      (log/warn e "No connection to nrepl, trying to re-establish (2)!")
+      (connect-to-nrepl (:host @conn) (:port @conn))
+      (process-message* channel data))))
 
 (defn ring-handler
   "This ring handler expects the client to make a websocket connection to the endpoint. It relays messages back and


### PR DESCRIPTION
Hi,

I'm not sure whether you're interested in this sort of changes or not, so feel free to just drop this PR. But for my use-case (combining GorillaREPL with ApacheSpark) it's really important, so it might be interesting for others. Main rational is I needed to avoid dependency conflicts.

Here's what I did:
- I separated nrepl code from gorillaREPL webserver to allow for both a standalone version (nrepl + GorillaREPL) and a GorillaREPL-version with the ability to connect to an existing nrepl server.
- I added CLI options to configure GorillaREPL
- I added the ability to re-establish a connection from GorillaREPL to the nrepl server. This is still work in progress, as the current REPL-state might get lost and the end-user will not be notified, but it's actually better than breaking the GorillaREPL (in my eyes).

Feel free to take whatever is necessary and wanted and be assured that I find GorillaREPL a really cool project!

Cheers,

Chris

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/jonyepsilon/gorilla-repl/220)
<!-- Reviewable:end -->
