### PR TITLE
Use paths relative to worksheet.html

### DIFF
--- a/resources/public/js/main.js
+++ b/resources/public/js/main.js
@@ -35,11 +35,15 @@ var app = function () {
         newWorksheet.addEventHandlers();
     };
 
+    var createPath = function(suffix) {
+        return window.location.pathname.replace(/[^/]+$/,suffix);
+    };
+
     // This starts the application. First of all we ask the server for configuration information, and then prepare the
     // UI and, if appropriate, load an initial worksheet.
     self.start = function (initialFilename) {
         // get hold of configuration information from the backend
-        $.get("/config")
+        $.get(createPath('config'))
             .done(function (data) {
                 self.config = data;
                 // If we've got the configuration, then start the app
@@ -124,7 +128,7 @@ var app = function () {
 
     // Helpers for loading and saving the worksheet - called by the various command handlers
     var saveToFile = function (filename, successCallback) {
-        $.post("/save", {
+        $.post(createPath('save'), {
             "worksheet-filename": filename,
             "worksheet-data": self.worksheet().toClojure()
         }).done(function () {
@@ -137,7 +141,7 @@ var app = function () {
 
     var loadFromFile = function (filename) {
         // ask the backend to load the data from disk
-        $.get("/load", {"worksheet-filename": filename})
+        $.get(createPath('load'), {"worksheet-filename": filename})
             .done(function (data) {
                 if (data['worksheet-data']) {
                     // parse and construct the new worksheet
@@ -178,7 +182,7 @@ var app = function () {
         self.palette.show("Scanning for files ...", []);
         $.ajax({
             type: "GET",
-            url: "/gorilla-files",
+            url: createPath('gorilla-files'),
             success: function (data) {
                 var paletteFiles = data.files.map(function (c) {
                     return {

--- a/resources/public/js/repl-ws.js
+++ b/resources/public/js/repl-ws.js
@@ -21,8 +21,9 @@ var repl = (function () {
     // TODO: handle errors.
     self.connect = function (successCallback, failureCallback) {
         // hard to believe we have to do this
-        var loc = window.location;
-        var url = "ws://" + loc.hostname + ":" + loc.port + "/repl";
+        var loc = window.location,
+            url = "ws://" + loc.hostname + ":" + loc.port + loc.pathname.replace(/[^/]+$/,'repl');
+
         self.ws = new WebSocket(url);
 
         // we first install a handler that will capture the session id from the clone message. Once it's done its work


### PR DESCRIPTION
Its just a few lines allowing gorilla repl to be mounted in any webapp. This change eliminates the need to maintain changed copies of the worksheet and two js files in the embedding app.

I got the while thing working now (see #227 ), and I have some more small tweaks to come soon. 