### PR TITLE
Add viewer support for IPFS files.

### DIFF
--- a/resources/gorilla-repl-client/js-viewer/ipfs.js
+++ b/resources/gorilla-repl-client/js-viewer/ipfs.js
@@ -1,0 +1,13 @@
+/*
+ * This file is part of gorilla-repl. Copyright (C) 2014-, Jony Hudson.
+ *
+ * gorilla-repl is licenced to you under the MIT licence. See the file LICENCE.txt for full details.
+ */
+
+var getFromIpfs = function (hash, callback) {
+    $.get("http://gateway.ipfs.io/ipfs/" + hash, callback);
+};
+
+var getFromIpns = function (hash, callback) {
+    $.get("http://gateway.ipfs.io/ipns/" + hash, callback);
+};

--- a/resources/gorilla-repl-client/js-viewer/main-viewer.js
+++ b/resources/gorilla-repl-client/js-viewer/main-viewer.js
@@ -27,15 +27,14 @@ var app = function () {
         self.copyBoxVisible(false);
     };
 
-    self.start = function (worksheetData, sourceURL, worksheetName, source) {
+    self.start = function (worksheetData, sourceURL, worksheetName, host) {
 
         var ws = worksheet();
         ws.segments = ko.observableArray(worksheetParser.parse(worksheetData));
         self.worksheet(ws);
         self.sourceURL(sourceURL);
         self.filename(worksheetName);
-        self.source(source);
-        self.host((source.toLowerCase() === "bitbucket") ? "Bitbucket" : "GitHub");
+        self.host(host);
 
         // wire up the UI
         ko.applyBindings(self, document.getElementById("document"));
@@ -64,14 +63,14 @@ $(function () {
             var repo = getParameterByName("repo");
             var path = getParameterByName("path");
             getFromGithub(user, repo, path, function (data) {
-                viewer.start(data, "https://github.com/" + user + "/" + repo, path, source);
+                viewer.start(data, "https://github.com/" + user + "/" + repo, path, "GitHub");
             });
             return;
         case "gist":
             var id = getParameterByName("id");
             var filename = getParameterByName("filename");
             getFromGist(id, filename, function (data) {
-                viewer.start(data,  "https://gist.github.com/" + id, filename, source);
+                viewer.start(data,  "https://gist.github.com/" + id, filename, "GitHub");
             });
             return;
         case "bitbucket":
@@ -80,7 +79,19 @@ $(function () {
             var path = getParameterByName("path");
             var revision = getParameterByName("revision") || "HEAD";
             getFromBitbucket(user, repo, path, revision, function (data) {
-                viewer.start(data, "https://bitbucket.org/" + user + "/" + repo, path, source);
+                viewer.start(data, "https://bitbucket.org/" + user + "/" + repo, path, "Bitbucket");
+            });
+            return;
+        case "ipfs":
+            var hash = getParameterByName("hash");
+            getFromIpfs(hash, function(data) {
+                viewer.start(data, "http://gateway.ipfs.io/ipfs/" + hash, hash, "IPFS");
+            });
+            return;
+        case "ipns":
+            var hash = getParameterByName("hash");
+            getFromIpns(hash, function(data) {
+                viewer.start(data, "http://gateway.ipfs.io/ipns/" + hash, hash, "IPFS");
             });
             return;
         case "test":

--- a/resources/gorilla-repl-client/view.html
+++ b/resources/gorilla-repl-client/view.html
@@ -40,6 +40,7 @@
     <script type="text/javascript" src="js-viewer/worksheet-viewer.js"></script>
     <script type="text/javascript" src="js-viewer/github.js"></script>
     <script type="text/javascript" src="js-viewer/bitbucket.js"></script>
+    <script type="text/javascript" src="js-viewer/ipfs.js"></script>
     <script type="text/javascript" src="js-viewer/main-viewer.js"></script>
 
     <title data-bind="text: title">Gorilla REPL viewer</title>


### PR DESCRIPTION
This adds viewer support for files on [IPFS](https://ipfs.io/), by extending viewer to two new sources:
- `view.html?source=ipfs&hash=<ipfs-hash>`
- `view.html?source=ipns&hash=<ipns-hash>`

You can try it with the one of the example files I put on IPFS: `QmbRdyLXiFWrKc5hW1NbvpUxF9tLovWCPgiz4BDhjD9k3j`
***
Also, the viewer is now hosted on IPFS with added native support (relative IPFS paths): [`QmTjbCM2JEM7HEyiuSGYzzSnVctWXozaMpiGAKTDCadiZn`](https://ipfs.io/ipfs/QmTjbCM2JEM7HEyiuSGYzzSnVctWXozaMpiGAKTDCadiZn/view.html?source=ipfs&hash=QmbRdyLXiFWrKc5hW1NbvpUxF9tLovWCPgiz4BDhjD9k3j)
That version is in this [repo](https://github.com/keorn/ipfs-gorilla-repl).