### PR TITLE
Save without markup

### DIFF
--- a/src/gorilla_repl/handle.clj
+++ b/src/gorilla_repl/handle.clj
@@ -40,7 +40,9 @@
       (let [marked-down-data (apply str (interpose "\n" (filter
                                                           #(and (> (count %) 1) (not= ";;" (subs % 0 2)))
                                                           (clojure.string/split ws-data #"\n"))))
-            marked-down-file (str ws-file ".clj")]
+            marked-down-file (if (and (> (count ws-file) 3) (= (apply str (take-last 4 ws-file)) ".clj"))
+                                 (apply str (concat (drop-last 4 ws-file) "_raw.clj"))
+                                 (str ws-file "_raw.clj"))]
         (print (str "Saving: " marked-down-file " ... "))
         (spit marked-down-file marked-down-data)
         (println (str "done. [" (java.util.Date.) "]"))

--- a/src/gorilla_repl/handle.clj
+++ b/src/gorilla_repl/handle.clj
@@ -37,10 +37,17 @@
   ;; TODO: error handling!
   (when-let [ws-data (:worksheet-data (:params req))]
     (when-let [ws-file (:worksheet-filename (:params req))]
-      (print (str "Saving: " ws-file " ... "))
-      (spit ws-file ws-data)
-      (println (str "done. [" (java.util.Date.) "]"))
-      (res/response {:status "ok"}))))
+      (let [marked-down-data (apply str (interpose "\n" (filter
+                                                          #(and (> (count %) 1) (not= ";;" (subs % 0 2)))
+                                                          (clojure.string/split ws-data #"\n"))))
+            marked-down-file (str ws-file ".clj")]
+        (print (str "Saving: " marked-down-file " ... "))
+        (spit marked-down-file marked-down-data)
+        (println (str "done. [" (java.util.Date.) "]"))
+        (print (str "Saving: " ws-file " ... "))
+        (spit ws-file ws-data)
+        (println (str "done. [" (java.util.Date.) "]"))
+        (res/response {:status "ok"})))))
 
 ;; More ugly atom usage to support defroutes
 (def ^:private excludes (atom #{".git"}))


### PR DESCRIPTION
Saves a .clj file with only the clojure code that was in the worksheet.  Note that lines beginning with ";;" (for commenting) will not save into this file.  Use a single ";" or preferably the reader macro, #_"comment string"
