### PR TITLE
Support Clojure 1.9

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -8,7 +8,7 @@
   :license {:name "MIT"}
   :dependencies ^:replace [[org.clojure/clojure "1.6.0"]
                            [http-kit "2.1.18"]
-                           [ring/ring-json "0.3.1"]
+                           [ring/ring-json "0.4.0"]
                            [cheshire "5.3.1"]
                            [compojure "1.1.8"]
                            [org.slf4j/slf4j-api "1.7.7"]


### PR DESCRIPTION
Upgrade ring-json to 0.4.0 so that ring-core is upgraded to 1.4.0, which includes some NS fixes so that it can run on clojure 1.9 alpha.