### PR TITLE
Accept an :nrepl-host configuration option

### DIFF
--- a/src/gorilla_repl/core.clj
+++ b/src/gorilla_repl/core.clj
@@ -34,6 +34,7 @@
         webapp-requested-port (or (:port conf) 0)
         ip (or (:ip conf) "127.0.0.1")
         nrepl-requested-port (or (:nrepl-port conf) 0)  ;; auto-select port if none requested
+        nrepl-requested-host (or (:nrepl-host conf) "127.0.0.1")
         nrepl-port-file (io/file (or (:nrepl-port-file conf) ".nrepl-port"))
         gorilla-port-file (io/file (or (:gorilla-port-file conf) ".gorilla-port"))
         project (or (:project conf) "no project")
@@ -47,7 +48,7 @@
     ;; check for updates
     (version/check-for-update version)  ;; runs asynchronously
     ;; first startup nREPL
-    (nrepl/start-and-connect nrepl-requested-port nrepl-port-file)
+    (nrepl/start-and-connect nrepl-requested-port nrepl-requested-host nrepl-port-file)
     ;; and then the webserver
     (let [s (server/run-server #'app-routes {:port webapp-requested-port :join? false :ip ip :max-body 500000000})
           webapp-port (:local-port (meta s))]

--- a/src/gorilla_repl/nrepl.clj
+++ b/src/gorilla_repl/nrepl.clj
@@ -10,10 +10,11 @@
 (def nrepl (atom nil))
 
 (defn start-and-connect
-  ([nrepl-requested-port repl-port-file]
+  ([nrepl-requested-port nrepl-requested-host repl-port-file]
    (let [cider-mw (map resolve cider/cider-middleware)
          middleware (conj cider-mw #'render-mw/render-values)
          nr (nrepl-server/start-server :port nrepl-requested-port
+                                       :bind nrepl-requested-host
                                        :handler (apply nrepl-server/default-handler middleware))
          nrepl-port (:port nr)]
      (println "Started nREPL server on port" nrepl-port)


### PR DESCRIPTION
This will override the host binding for nrepl, allowing users to bind its socket to something other than localhost.